### PR TITLE
Add delete schedule endpoint

### DIFF
--- a/src/api/routes/schedule.py
+++ b/src/api/routes/schedule.py
@@ -1,9 +1,7 @@
 from datetime import datetime
 from scr.utils import celery_app
-from fastapi import HTTPException, APIRouter, Depends
-from typing import Annotated
-
-from src.utils.database import Database
+from fastapi import HTTPException, APIRouter
+from src.api.dependencies import databaseDepends
 
 router = APIRouter(prefix="/schedule")
 
@@ -11,13 +9,13 @@ router = APIRouter(prefix="/schedule")
 def delete_schedule(
     prompt_id: str,
     brand_report_id: str,
-    db: Annotated[Database, Depends(Database)]
+    database: databaseDepends,
 ):
     """
     Delete a schedule entry based on prompt_id and brand_report_id.
     """
     try:
-        result = db.delete_schedule(prompt_id=prompt_id, brand_report_id=brand_report_id)
+        result = database.delete_schedule(prompt_id=prompt_id, brand_report_id=brand_report_id)
         if result:
             return {"status": "success", "message": "Schedule deleted successfully"}
         else:

--- a/src/api/routes/schedule.py
+++ b/src/api/routes/schedule.py
@@ -5,3 +5,18 @@ from fastapi import HTTPException, APIRouter
 import time
 
 router = APIRouter(prefix="/schedule")
+
+
+@router.delete("/delete")
+def delete_schedule(prompt_id: str, brand_report_id: str, db=databaseDepends):
+    """
+    Delete a schedule entry based on prompt_id and brand_report_id.
+    """
+    try:
+        result = db.delete_schedule(prompt_id=prompt_id, brand_report_id=brand_report_id)
+        if result:
+            return {"status": "success", "message": "Schedule deleted successfully"}
+        else:
+            raise HTTPException(status_code=404, detail="Schedule not found")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/src/api/routes/schedule.py
+++ b/src/api/routes/schedule.py
@@ -1,14 +1,18 @@
 from datetime import datetime
-from src.utils import celery_app
-from src.api.dependencies import databaseDepends
-from fastapi import HTTPException, APIRouter
-import time
+from scr.utils import celery_app
+from fastapi import HTTPException, APIRouter, Depends
+from typing import Annotated
+
+from src.utils.database import Database
 
 router = APIRouter(prefix="/schedule")
 
-
 @router.delete("/delete")
-def delete_schedule(prompt_id: str, brand_report_id: str, db=databaseDepends):
+def delete_schedule(
+    prompt_id: str,
+    brand_report_id: str,
+    db: Annotated[Database, Depends(Database)]
+):
     """
     Delete a schedule entry based on prompt_id and brand_report_id.
     """

--- a/src/utils/database.py
+++ b/src/utils/database.py
@@ -44,6 +44,25 @@ class Database:
             session.add(schedule)
             session.commit()
 
+    def delete_schedule(self, prompt_id: str, brand_report_id: str):
+        """Delete a schedule based on prompt_id and brand_report_id"""
+        print(f"Deleting schedule for prompt_id={prompt_id} and brand_report_id={brand_report_id}")
+        with Session(self.engine) as session:
+            stmt = select(Schedules).where(
+                Schedules.prompt_id == prompt_id,
+                Schedules.brand_report_id == brand_report_id
+            )
+            schedule = session.exec(stmt).first()
+            if schedule:
+                session.delete(schedule)
+                session.commit()
+                print("Schedule deleted successfully")
+                return True
+            else:
+                print("No matching schedule found")
+                return False
+
+
     #  -------- Reports ----------
 
     def add_report(


### PR DESCRIPTION
PR Description

Summary:
This PR introduces a new DELETE endpoint in the /schedule API that allows deleting a schedule entry from the database based on its prompt_id and brand_report_id. The functionality is implemented in database.py and exposed through FastAPI using dependency injection.

Changes made:

Database class (database.py)

Added the method delete_schedule(prompt_id: str, brand_report_id: str)

Deletes a schedule if it exists, otherwise returns False.

API endpoint (schedule.py)

Added a new DELETE endpoint: /schedule/delete

Uses FastAPI dependency injection: db: Annotated[Database, Depends(Database)]

Returns:

200 OK with a success message if the schedule is deleted

404 Not Found if no schedule matches the provided IDs

500 Internal Server Error if an unexpected error occurs